### PR TITLE
holiday-manager-apiのログを出力する #26

### DIFF
--- a/holiday-manager-api/pom.xml
+++ b/holiday-manager-api/pom.xml
@@ -49,11 +49,6 @@
 		    <version>42.2.10</version>
 		</dependency>
 		<dependency>
-			<groupId>org.lazyluke</groupId>
-			<artifactId>log4jdbc-remix</artifactId>
-			<version>0.2.7</version>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
動作確認：log4jの依存を削除